### PR TITLE
fix: update deprecated qdrant-client API calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = ">=3.8,<=3.13"
 txtai = ">=5.0.0"
-qdrant-client = "^1.9.1"
+qdrant-client = ">=1.9.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"

--- a/src/qdrant_txtai/ann/qdrant.py
+++ b/src/qdrant_txtai/ann/qdrant.py
@@ -4,11 +4,11 @@ from txtai.ann import ANN
 from grpc import RpcError
 from qdrant_client import QdrantClient
 from qdrant_client.http.exceptions import UnexpectedResponse
-from qdrant_client.http.models import (
+from qdrant_client.models import (
         PointIdsList,
         VectorParams,
         Distance,
-        SearchRequest,
+        QueryRequest,
         SearchParams,
     )
 
@@ -59,7 +59,9 @@ class Qdrant(ANN):
             raise ValueError(f"Unsupported Qdrant similarity metric: {metric_name}")
         collection_config = self.qdrant_config.get("collection_config", {})
 
-        self.qdrant_client.recreate_collection(
+        if self.qdrant_client.collection_exists(self.collection_name):
+            self.qdrant_client.delete_collection(self.collection_name)
+        self.qdrant_client.create_collection(
             collection_name=self.collection_name,
             vectors_config=VectorParams(
                 size=vector_size,
@@ -90,21 +92,22 @@ class Qdrant(ANN):
 
     def search(self, queries, limit):
         search_params = self.qdrant_config.get("search_params", {})
-        search_results = self.qdrant_client.search_batch(
+        requests = [
+            QueryRequest(
+                query=query.tolist(),
+                params=SearchParams(**search_params) if search_params else None,
+                limit=limit,
+            )
+            for query in queries
+        ]
+        search_results = self.qdrant_client.query_batch_points(
             collection_name=self.collection_name,
-            requests=[
-                SearchRequest(
-                    vector=query.tolist(),
-                    params=SearchParams(**search_params),
-                    limit=limit,
-                )
-                for query in queries
-            ],
+            requests=requests,
         )
 
         results = []
-        for search_result in search_results:
-            results.append([(entry.id, entry.score) for entry in search_result])
+        for batch_result in search_results:
+            results.append([(point.id, point.score) for point in batch_result.points])
         return results
 
     def count(self):


### PR DESCRIPTION
## Summary

Fixes #10 - AttributeError: 'QdrantClient' object has no attribute 'search_batch'

- Replace `search_batch` with `query_batch_points` for batch search operations
- Replace deprecated `recreate_collection` with `collection_exists` + `delete_collection` + `create_collection`
- Update imports from `qdrant_client.http.models` to `qdrant_client.models`
- Relax `qdrant-client` version constraint to `>=1.9.1` to support newer versions

## Test plan

- [x] In-memory tests pass locally with qdrant-client 1.16.1
- [ ] CI integration tests with Qdrant server